### PR TITLE
display auth error to user

### DIFF
--- a/notice_me.py
+++ b/notice_me.py
@@ -1,5 +1,6 @@
 import json
 import requests
+import sys
 
 
 class AttentionWhore(object):
@@ -20,6 +21,9 @@ class AttentionWhore(object):
                 "https://api.github.com/search/users?q=followers:%3E" +
                 str(min_followers) + "&per_page=300&page=" + str(page),
                 auth=(self.gh_username, self.gh_access))
+
+            if search_request.status_code == 401:
+                sys.exit(json.loads(search_request.text)['message'])
 
             search_results = json.loads(search_request.text)
 


### PR DESCRIPTION
If the request returns a `401 Unauthorized`, display the message GitHub returns to the user so they know if it was two-factor, bad credentials, etc.