### PR TITLE
Use real max "per_page" value in "/search/users"

### DIFF
--- a/notice_me.py
+++ b/notice_me.py
@@ -18,7 +18,7 @@ class NoticeMe:
 
             search_request = requests.get(
                 "https://api.github.com/search/users?q=followers:%3E" +
-                str(min_followers) + "&per_page=300&page=" + str(page),
+                str(min_followers) + "&per_page=100&page=" + str(page),
                 auth=(self.gh_username, self.gh_access))
 
             search_results = json.loads(search_request.text)


### PR DESCRIPTION
According to the `GitHub`'s documentation, the actual maximal `per_page` value for the `/search/users` api's endpoint is *100*:

> https://developer.github.com/v3/#pagination